### PR TITLE
Fixed issue with additional categories appearing when searching

### DIFF
--- a/project/lib/helpers.php
+++ b/project/lib/helpers.php
@@ -76,10 +76,16 @@ function getPrice($productID) {
 
 function getCategories() {
     $db = getDB();
-    $stmt = (has_role("Admin")) ? $db->prepare("SELECT category from Products WHERE NOT category='' ") : $db->prepare("SELECT category from Products WHERE NOT category='' AND visibility='1'");
+    $stmt = (has_role("Admin")) ? $db->prepare("SELECT category from Products WHERE NOT category='' ") : $db->prepare("SELECT category from Products WHERE NOT category='' AND visibility='1' AND quantity!='0'");
     $r = $stmt->execute();
     $categories = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    return $categories;
+    $return_cats = [];
+    foreach($categories as $cat) {
+        if (!in_array($cat, $return_cats)) {
+            array_push($return_cats, $cat);
+        }
+    }
+    return $return_cats;
 }
 
 function getURL($path) {


### PR DESCRIPTION
There was 2 issues with shop.php showing the categories. The first being that if say there was multiple products the same category, if was showing that category that many times in the category dropdown. The other issue was that although it was just showing the categories of those products visible to the user, it was not excluding the products that were set to visible but also had a quantity of 0 so they were not shown to the user.

Fix for issue #11